### PR TITLE
removed references to old action

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,14 +247,7 @@ Which will print `Hello, Jose!` in the template.
 
 ## Built-In Plugins ##
 
-Oz comes with a number of built-in plugins to faciliate rapid development. You
-can get details of what these plugins expose via:
-
-    oz explore <plugin name>
-
-Example:
-
-    oz explore oz.core
+Oz comes with a number of built-in plugins to faciliate rapid development.
 
 ### Core (`oz.core`) ###
 


### PR DESCRIPTION
looks like the `explore` action was removed, but a few mentions of it were left in the README file, leading to a bit of confusion on my part, trying to figure out why doing 

```bash
$ oz explore oz.core
```
wasn't working, but then i found this: 806ddae8aae239073e337e9231d0eadb366cd1d5