### PR TITLE
passed route argument as tuple in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ An example handler using API middleware:
         def get(self):
             self.respond({"foo": "bar"})
 
-    oz.route("/", ExampleApiHandler)
+    oz.route(("/", ExampleApiHandler))
 
 ## Middleware ##
 


### PR DESCRIPTION
if you define a route like displayed, you get an error, because the `oz.route` function isnt looking for 2 seperate arguments, its looking for a single `route` argument, so you need to pass it as a tuple, or a list.