### PR TITLE
Add xheaders=True option to the HTTPServer instance

### DIFF
--- a/oz/core/actions.py
+++ b/oz/core/actions.py
@@ -77,7 +77,7 @@ def server():
         else:
             ssl_options = None
 
-        srv = tornado.httpserver.HTTPServer(application, ssl_options=ssl_options)
+        srv = tornado.httpserver.HTTPServer(application, ssl_options=ssl_options, xheaders=True)
         srv.bind(oz.settings["port"])
 
         if oz.settings["debug"]:

--- a/oz/core/actions.py
+++ b/oz/core/actions.py
@@ -77,7 +77,7 @@ def server():
         else:
             ssl_options = None
 
-        srv = tornado.httpserver.HTTPServer(application, ssl_options=ssl_options, xheaders=True)
+        srv = tornado.httpserver.HTTPServer(application, ssl_options=ssl_options, xheaders=oz.settings["xheaders"])
         srv.bind(oz.settings["port"])
 
         if oz.settings["debug"]:

--- a/oz/core/options.py
+++ b/oz/core/options.py
@@ -14,6 +14,7 @@ oz.options(
     gzip = dict(type=bool, help="Enables gzip output."),
     wsgi_mode = dict(type=bool, default=False, help="Use WSGI mode."),
     server_workers = dict(type=int, default=1, help="The number of server workers to run concurrently."),
+    xheaders = dict(type=bool, default=False, help="Determine remote_ip from X-Remote-Ip/X-Forwarded-For headers"),
 
     ssl_cert_file = dict(type=str, default=None, help="The SSL certificate file. If unspecified, SSL support will be disabled."),
     ssl_key_file = dict(type=str, default=None, help="The SSL key file. If unspecified, SSL support will be disabled."),


### PR DESCRIPTION
This instructs Tornado to pass on the value of the X-Real-Ip/X-Forwared-For headers to the remote_ip field. This is useful when running behind a reverse proxy or load balancer (which most sites do these days).

@ysimonson This is required for the location tracking endpoint I'm implementing on The Muse. Well, it's not _strictly_ required --- we could duplicate the functionality on our end --- but it makes the code cleaner. 

See [here](http://www.tornadoweb.org/en/stable/httpserver.html#tornado.httpserver.HTTPServer) for an explanation.