### PR TITLE
Remove exception raise on missing experiment

### DIFF
--- a/oz/bandit/__init__.py
+++ b/oz/bandit/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, with_statement, unicode_literals
 
 from tornado import escape, util
+from tornado.log import app_log as logger
 from .actions import *
 from .middleware import *
 from .tests import *
@@ -179,7 +180,7 @@ class Experiment(object):
         results = pipe.execute()
 
         if results[0] == None:
-            raise ExperimentException(self.name, "Does not exist")
+            logger.warning(self.name, "Does not exist")
 
         self.metadata = parse_json(results[0])
         self.choice_names = parse_json(results[1]) if results[1] != None else []


### PR DESCRIPTION
This change will use tornado.log.app_log.warning to notify of missing
experiment data and prevent sites from going down.