### PR TITLE
Allow setting session cookie domain

### DIFF
--- a/oz/redis_sessions/middleware.py
+++ b/oz/redis_sessions/middleware.py
@@ -24,7 +24,11 @@ class RedisSessionMiddleware(object):
 
             if not session_id:
                 session_id = oz.redis_sessions.random_hex(20)
-                self.set_secure_cookie("session_id", session_id.encode('utf-8'), httponly=True)
+                self.set_secure_cookie(
+                    name="session_id",
+                    value=session_id.encode('utf-8'),
+                    domain=oz.settings.get("cookie_domain"),
+                    httponly=True)
 
             password_salt = oz.settings["session_salt"]
             self._cached_session_key = "session:%s:v4" % oz.redis_sessions.password_hash(session_id, password_salt=password_salt)

--- a/oz/redis_sessions/options.py
+++ b/oz/redis_sessions/options.py
@@ -6,5 +6,6 @@ import oz
 
 oz.options(
     session_salt = dict(type=str, help="Salt used for session security"),
-    session_time = dict(type=int, help="Number of seconds of session inactivity before timeout")
+    session_time = dict(type=int, help="Number of seconds of session inactivity before timeout"),
+    cookie_domain = dict(type=str, help="The domain of the session cookie")
 )


### PR DESCRIPTION
Based on discussion in #16 , we decided that Oz needed to have an option that allows you to specify a domain for its session cookies. That way, the muse can share cookies between all its subdomains (i.e. *.themuse.com).