### PR TITLE
Update cache-buster key name

### DIFF
--- a/oz/aws_cdn/__init__.py
+++ b/oz/aws_cdn/__init__.py
@@ -27,15 +27,15 @@ def static_url(redis, path):
 
 def get_cache_buster(redis, path):
     """Gets the cache buster value for a given file path"""
-    return escape.to_unicode(redis.hget("cache:{}:v3".format(oz.settings["s3_bucket"]), path))
+    return escape.to_unicode(redis.hget("cache-buster:{}:v3".format(oz.settings["s3_bucket"]), path))
 
 def set_cache_buster(redis, path, hash):
     """Sets the cache buster value for a given file path"""
-    redis.hset("cache:{}:v3".format(oz.settings["s3_bucket"]), path, hash)
+    redis.hset("cache-buster:{}:v3".format(oz.settings["s3_bucket"]), path, hash)
 
 def remove_cache_buster(redis, path):
     """Removes the cache buster for a given file"""
-    redis.hdel("cache:{}:v3".format(oz.settings["s3_bucket"]), path)
+    redis.hdel("cache-buster:{}:v3".format(oz.settings["s3_bucket"]), path)
 
 def get_bucket(s3_bucket=None, validate=False):
     """Gets a bucket from specified settings"""

--- a/oz/aws_cdn/__init__.py
+++ b/oz/aws_cdn/__init__.py
@@ -27,15 +27,15 @@ def static_url(redis, path):
 
 def get_cache_buster(redis, path):
     """Gets the cache buster value for a given file path"""
-    return escape.to_unicode(redis.hget("cache-buster:v2", path))
+    return escape.to_unicode(redis.hget("cache:{}:v3".format(oz.settings["s3_bucket"]), path))
 
 def set_cache_buster(redis, path, hash):
     """Sets the cache buster value for a given file path"""
-    redis.hset("cache-buster:v2", path, hash)
+    redis.hset("cache:{}:v3".format(oz.settings["s3_bucket"]), path, hash)
 
 def remove_cache_buster(redis, path):
     """Removes the cache buster for a given file"""
-    redis.hdel("cache-buster:v2", path)
+    redis.hdel("cache:{}:v3".format(oz.settings["s3_bucket"]), path)
 
 def get_bucket(s3_bucket=None, validate=False):
     """Gets a bucket from specified settings"""


### PR DESCRIPTION
If your s3 assets are in different buckets the cache buster will use a key which could conflict for same file names in different buckets.  This updates cache busters to use different keys based on s3_bucket name, so we can have separate caches for different asset buckets.