### PR TITLE
Configurable ioloops

### DIFF
--- a/oz/core/actions.py
+++ b/oz/core/actions.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, with_statement
 
 import tornado.web
 import tornado.wsgi
-import tornado.ioloop
 import tornado.httpserver
 import wsgiref.simple_server
 import oz
@@ -94,8 +93,24 @@ def server():
         else:
             # Forks multiple sub-processes
             srv.start(oz.settings["server_workers"])
-        
+
+    ioloop = oz.settings["ioloop"]
+
+    if ioloop == "asyncio":
+        from tornado.platform.asyncio import AsyncIOMainLoop
+        import asyncio
+        AsyncIOMainLoop().install()
+        asyncio.get_event_loop().run_forever()
+    elif ioloop == "twisted":
+        from tornado.platform.twisted import TwistedIOLoop
+        from twisted.internet import reactor
+        TwistedIOLoop().install()
+        reactor.run()
+    elif ioloop == None:
+        import tornado.ioloop
         tornado.ioloop.IOLoop.instance().start()
+    else:
+        raise Exception("Unknown ioloop type: %s" % ioloop)
 
 @oz.action
 def repl():

--- a/oz/core/actions.py
+++ b/oz/core/actions.py
@@ -107,8 +107,8 @@ def server():
         TwistedIOLoop().install()
         reactor.run()
     elif ioloop == None:
-        import tornado.ioloop
-        tornado.ioloop.IOLoop.instance().start()
+        from tornado import ioloop
+        ioloop.IOLoop.instance().start()
     else:
         raise Exception("Unknown ioloop type: %s" % ioloop)
 

--- a/oz/core/options.py
+++ b/oz/core/options.py
@@ -19,5 +19,6 @@ oz.options(
     ssl_cert_file = dict(type=str, default=None, help="The SSL certificate file. If unspecified, SSL support will be disabled."),
     ssl_key_file = dict(type=str, default=None, help="The SSL key file. If unspecified, SSL support will be disabled."),
     ssl_cert_reqs = dict(type=int, default=0, help="Whether certificates are required from the other side of the connection. 0 = certificates ignored, 1 = certificates optional, 2 = certificates required."),
-    ssl_ca_certs = dict(type=str, default=None, help="SSL CA certificates file.")
+    ssl_ca_certs = dict(type=str, default=None, help="SSL CA certificates file."),
+    ioloop = dict(type=str, default=None, help="If set, an alternative IOLoop will be used rather than the default one. Valid options: 'asyncio', 'twisted'."),
 )

--- a/oz/core/options.py
+++ b/oz/core/options.py
@@ -20,5 +20,5 @@ oz.options(
     ssl_key_file = dict(type=str, default=None, help="The SSL key file. If unspecified, SSL support will be disabled."),
     ssl_cert_reqs = dict(type=int, default=0, help="Whether certificates are required from the other side of the connection. 0 = certificates ignored, 1 = certificates optional, 2 = certificates required."),
     ssl_ca_certs = dict(type=str, default=None, help="SSL CA certificates file."),
-    ioloop = dict(type=str, default=None, help="If set, an alternative IOLoop will be used rather than the default one. Valid options: 'asyncio', 'twisted'."),
+    server_type = dict(type=str, default=None, help="By default, tornado will be started with the default ioloop. If this is set, a custom server can be used instead. Valid options: 'asyncio', 'twisted' or 'wsgi'."),
 )


### PR DESCRIPTION
We've been using this for our internal deployer, to allow the use of the asyncio-based ioloop rather than the default tornado one. It seems to be working, however I've just merged in the recent changes to gracefully handle SIGINT/SIGTERM from develop into here - the combination of the two changes hasn't seen any production usage yet.