### PR TITLE
Ensure sqlalchemy session close called

### DIFF
--- a/oz/sqlalchemy/middleware.py
+++ b/oz/sqlalchemy/middleware.py
@@ -26,9 +26,10 @@ class SQLAlchemyMiddleware(object):
         """
 
         if hasattr(self, "db_conn"):
-            if self.get_status() >= 200 and self.get_status() <= 399:
-                self.db_conn.commit()
-            else:
-                self.db_conn.rollback()
-
-            self.db_conn.close()
+            try:
+                if self.get_status() >= 200 and self.get_status() <= 399:
+                    self.db_conn.commit()
+                else:
+                    self.db_conn.rollback()
+            finally:
+                self.db_conn.close()

--- a/oz/sqlalchemy/middleware.py
+++ b/oz/sqlalchemy/middleware.py
@@ -2,6 +2,10 @@
 
 from __future__ import absolute_import, division, print_function, with_statement, unicode_literals
 
+import sys
+
+import tornado.log
+
 import oz
 import oz.sqlalchemy
 
@@ -32,6 +36,8 @@ class SQLAlchemyMiddleware(object):
                     self.db_conn.commit()
                 else:
                     self.db_conn.rollback()
+            except:
+                tornado.log.app_log.warning("Error occurred during database transaction cleanup: %s", str(sys.exc_info()[0]))
             finally:
                 self.db_conn.close()
 
@@ -44,5 +50,7 @@ class SQLAlchemyMiddleware(object):
         if hasattr(self, "db_conn"):
             try:
                 self.db_conn.rollback()
+            except:
+                tornado.log.app_log.warning("Error occurred during database transaction cleanup: %s", str(sys.exc_info()[0]))
             finally:
                 self.db_conn.close()

--- a/oz/sqlalchemy/middleware.py
+++ b/oz/sqlalchemy/middleware.py
@@ -38,6 +38,7 @@ class SQLAlchemyMiddleware(object):
                     self.db_conn.rollback()
             except:
                 tornado.log.app_log.warning("Error occurred during database transaction cleanup: %s", str(sys.exc_info()[0]))
+                raise
             finally:
                 self.db_conn.close()
 
@@ -52,5 +53,6 @@ class SQLAlchemyMiddleware(object):
                 self.db_conn.rollback()
             except:
                 tornado.log.app_log.warning("Error occurred during database transaction cleanup: %s", str(sys.exc_info()[0]))
+                raise
             finally:
                 self.db_conn.close()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.8.4"
+VERSION = "0.8.5"
 
 setup(
     name="Oz",


### PR DESCRIPTION
There are cases where `on_finish` is not called in tornado. For example, `on_finish` will not be called if the requester's connection is closed before an asynchronous request has completed. We need to ensure resources are closed in this case, and use `on_connection_close` to this end.