### PR TITLE
A new key is created if none exists when 'get_file' is called, should…

### DIFF
--- a/oz/aws_cdn/__init__.py
+++ b/oz/aws_cdn/__init__.py
@@ -173,7 +173,7 @@ class S3File(CDNFile):
 
     def copy(self, new_path, replace=False):
         """Uses boto to copy the file to the new path instead of uploading another file to the new key"""
-        if replace or get_file(new_path).key is None:
+        if replace or get_file(new_path).exists():
             self.key.copy(self.key.bucket, new_path)
             return True
         return False

--- a/oz/aws_cdn/__init__.py
+++ b/oz/aws_cdn/__init__.py
@@ -173,7 +173,7 @@ class S3File(CDNFile):
 
     def copy(self, new_path, replace=False):
         """Uses boto to copy the file to the new path instead of uploading another file to the new key"""
-        if replace or get_file(new_path).exists():
+        if replace or not get_file(new_path).exists():
             self.key.copy(self.key.bucket, new_path)
             return True
         return False


### PR DESCRIPTION
… be using '.exists()' instead of checking if key is None

This was my fault... oops.