### PR TITLE
Fix a bug with not extending redis session cookies

### DIFF
--- a/oz/redis_sessions/middleware.py
+++ b/oz/redis_sessions/middleware.py
@@ -22,13 +22,22 @@ class RedisSessionMiddleware(object):
                 except:
                     pass
 
-            if not session_id:
+            if session_id is None:
                 session_id = oz.redis_sessions.random_hex(20)
-                self.set_secure_cookie(
-                    name="session_id",
-                    value=session_id.encode('utf-8'),
-                    domain=oz.settings.get("cookie_domain"),
-                    httponly=True)
+
+            session_time = oz.settings["session_time"]
+            if session_time:
+                expires_days = session_time/60/60/24
+            else:
+                expires_days = 30
+
+            self.set_secure_cookie(
+                name="session_id",
+                value=session_id.encode('utf-8'),
+                domain=oz.settings.get("cookie_domain"),
+                httponly=True,
+                expires_days=expires_days,)
+
 
             password_salt = oz.settings["session_salt"]
             self._cached_session_key = "session:%s:v4" % oz.redis_sessions.password_hash(session_id, password_salt=password_salt)

--- a/oz/redis_sessions/middleware.py
+++ b/oz/redis_sessions/middleware.py
@@ -22,22 +22,20 @@ class RedisSessionMiddleware(object):
                 except:
                     pass
 
-            if session_id is None:
+            if not session_id:
                 session_id = oz.redis_sessions.random_hex(20)
 
             session_time = oz.settings["session_time"]
-            if session_time:
-                expires_days = session_time/60/60/24
-            else:
-                expires_days = 30
-
-            self.set_secure_cookie(
+            kwargs = dict(
                 name="session_id",
                 value=session_id.encode('utf-8'),
                 domain=oz.settings.get("cookie_domain"),
                 httponly=True,
-                expires_days=expires_days,)
+            )
+            if session_time:
+                kwargs["expires_days"] = round(session_time/60/60/24)
 
+            self.set_secure_cookie(**kwargs)
 
             password_salt = oz.settings["session_salt"]
             self._cached_session_key = "session:%s:v4" % oz.redis_sessions.password_hash(session_id, password_salt=password_salt)


### PR DESCRIPTION
There was a bug with the way oz was dealing with redis session. Oz would
extend the session key in redis, but didn't extend the expiration of the
`session_id`. This would cause all users to be logged out after the
cookie expiration time expired (which would be 30 days since the value
wasn't being set by oz). This update ensure that cookie is extended and
reset everytime the session key is accessed.