### PR TITLE
Enable log pretty-printing

### DIFF
--- a/oz/core/actions.py
+++ b/oz/core/actions.py
@@ -65,6 +65,8 @@ def init(project_name):
 def server():
     """Runs the server"""
 
+    tornado.log.enable_pretty_logging()
+
     # Get and validate the server_type
     server_type = oz.settings["server_type"]
     if server_type not in [None, "wsgi", "asyncio", "twisted"]:


### PR DESCRIPTION
Calling this function enables all the logging-related options, including pretty-printing, log levels, formatters, and log rotation.