### PR TITLE
Add support for creating a connection by redis url

### DIFF
--- a/oz/redis/__init__.py
+++ b/oz/redis/__init__.py
@@ -17,6 +17,9 @@ def create_connection():
 
     if settings["redis_cache_connections"] and _cached_connection != None:
         return _cached_connection
+    elif "redis_url" in settings:
+        conn = redis.StrictRedis.from_url(settings["redis_url"],
+                                          decode_responses=settings["redis_decode_responses"])
     else:
         conn = redis.StrictRedis(
             host=settings["redis_host"],
@@ -26,7 +29,7 @@ def create_connection():
             decode_responses=settings["redis_decode_responses"],
         )
 
-        if settings["redis_cache_connections"]:
-            _cached_connection = conn
+    if settings["redis_cache_connections"]:
+        _cached_connection = conn
 
-        return conn
+    return conn

--- a/oz/redis/options.py
+++ b/oz/redis/options.py
@@ -5,10 +5,11 @@ from __future__ import absolute_import, division, print_function, with_statement
 import oz
 
 oz.options(
-    redis_cache_connections = dict(type=bool, default=True, help="Whether to cache the redis connection between requests to prevent TCP slow start"),
-    redis_host = dict(type=str, default="localhost", help="Redis host"),
-    redis_port = dict(type=int, default=6379, help="Redis port"),
-    redis_db = dict(type=int, default=0, help="Redis database number"),
-    redis_password = dict(type=str, default=None, help="Password to the redis database"),
-    redis_decode_responses = dict(type=bool, default=False, help="Whether to decode redis responses automatically. Keep this False if you're handling binary data in redis."),
+    redis_cache_connections=dict(type=bool, default=True, help="Whether to cache the redis connection between requests to prevent TCP slow start"),
+    redis_url=dict(type=str, default=None, help="Redis URL. Overrides component-based redis settings."),
+    redis_host=dict(type=str, default="localhost", help="Redis host"),
+    redis_port=dict(type=int, default=6379, help="Redis port"),
+    redis_db=dict(type=int, default=0, help="Redis database number"),
+    redis_password=dict(type=str, default=None, help="Password to the redis database"),
+    redis_decode_responses=dict(type=bool, default=False, help="Whether to decode redis responses automatically. Keep this False if you're handling binary data in redis."),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 setup(
     name="Oz",


### PR DESCRIPTION
Use from_url if oz settings contain redis_url, otherwise fall back to
oz component-based settings for redis. from_url is a more flexible way
to specify redis connection information.