### PR TITLE
Allow boto to infer credentials from env/metadata

### DIFF
--- a/oz/aws_cdn/__init__.py
+++ b/oz/aws_cdn/__init__.py
@@ -48,7 +48,10 @@ def get_bucket(s3_bucket=None, validate=False):
         opts = {}
         if settings["s3_host"]:
             opts["host"] = settings["s3_host"]
-        return S3Connection(settings["aws_access_key"], settings["aws_secret_key"], **opts).get_bucket(s3_bucket, validate=validate)
+        if settings["aws_access_key"] and settings["aws_secret_key"]:
+            opts["aws_access_key_id"] = settings["aws_access_key"]
+            opts["aws_secret_access_key"] = settings["aws_secret_key"]
+        return S3Connection(**opts).get_bucket(s3_bucket, validate=validate)
     else:
         raise Exception("S3 not supported in this environment as boto is not installed")
 

--- a/oz/aws_cdn/options.py
+++ b/oz/aws_cdn/options.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, division, print_function, with_statement
 import oz
 
 oz.options(
-    aws_access_key = dict(type=str, help="AWS access key for CDN"),
-    aws_secret_key = dict(type=str, help="AWS secret key for CDN"),
+    aws_access_key = dict(type=str, default=None, help="AWS access key for CDN"),
+    aws_secret_key = dict(type=str, default=None, help="AWS secret key for CDN"),
     static_host = dict(type=str, help="CDN hostname for static assets"),
     s3_bucket = dict(type=str, default=None, help="S3 bucket for uploading CDN assets"),
     s3_host = dict(type=str, default=None, help="S3 host to use for signature generation")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.2.3"
+VERSION = "1.2.4"
 
 setup(
     name="Oz",
@@ -39,7 +39,7 @@ setup(
     ],
 
     extras_require={
-        "oz.aws_cdn": ["boto>=2.9.7"],
+        "oz.aws_cdn": ["boto>=2.47.0"],
         "oz.redis": ["redis>=2.6.0"],
         "oz.sqlalchemy": ["sqlalchemy>=0.7.8"],
         "datadog": ["ddtrace>=0.12.1"]


### PR DESCRIPTION
If aws_cdn is used but aws credentials are not provided, we allow boto to infer the credentials from environment or by contacting the metadata server. To support this we had to enforce a newer boto dependency.